### PR TITLE
Update RedisPool to work with redis 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.37.0", features = ["sync"] }
 async-trait = "0.1.80"
 tracing = "0.1.40"
 thiserror = "1.0.58"
-redis = { version = "0.25.3", features = ["aio", "tokio-comp"]}
+redis = { version = "0.26.0", features = ["aio", "tokio-comp"]}
 crossbeam-queue = "0.3.11"
 
 [dev-dependencies]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -50,7 +50,7 @@ where
                 .ignore()
                 .cmd("PING")
                 .arg(1)
-                .query_async::<_, (usize,)>(&mut con)
+                .query_async::<(usize,)>(&mut con)
                 .await;
 
             match res {


### PR DESCRIPTION
Currently, `RedisPool` doesn't work with `redis-rs 0.26.0` due to breaking change in it.
This PR adapts `RedisPool` to `redis-rs 0.26.0`.

(https://github.com/AkiraMiyakoda/RedisPool/commit/c4b55688088efa5c6e91b7f0d6458f739eabbe24#commitcomment-144809479)