### PR TITLE
Bump redis-rs to 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.37.0", features = ["sync"] }
 async-trait = "0.1.80"
 tracing = "0.1.40"
 thiserror = "1.0.58"
-redis = { version = "0.25.3", features = ["aio", "tokio-comp"]}
+redis = { version = "0.26.0", features = ["aio", "tokio-comp"]}
 crossbeam-queue = "0.3.11"
 
 [dev-dependencies]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -50,7 +50,7 @@ where
                 .ignore()
                 .cmd("PING")
                 .arg(1)
-                .query_async::<_, (usize,)>(&mut con)
+                .query_async::<(usize,)>(&mut con)
                 .await;
 
             match res {

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -20,7 +20,7 @@ pub async fn test_simple_get_set_series() -> anyhow::Result<()> {
             .set(i, i)
             .ignore()
             .get(i)
-            .query_async::<_, (i64,)>(&mut con)
+            .query_async::<(i64,)>(&mut con)
             .await?;
         assert_eq!(i, value);
     }
@@ -61,7 +61,7 @@ async fn get_set_byte_array(i: usize, pool: &ClusterRedisPool) -> anyhow::Result
         .set(i, &DATA[..])
         .ignore()
         .get(i)
-        .query_async::<_, (Vec<u8>,)>(&mut con)
+        .query_async::<(Vec<u8>,)>(&mut con)
         .await
         .context("Failed to set/get from redis")?;
 

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -21,7 +21,7 @@ pub async fn test_simple_get_set_series() -> anyhow::Result<()> {
             .set("test", i)
             .ignore()
             .get("test")
-            .query_async::<_, (i64,)>(&mut con)
+            .query_async::<(i64,)>(&mut con)
             .await?;
         assert_eq!(i, value);
     }
@@ -69,7 +69,7 @@ async fn get_set_byte_array<C: ConnectionLike>(key: &str, con: &mut C) -> anyhow
         .set(key, &DATA[..])
         .ignore()
         .get(key)
-        .query_async::<_, (Vec<u8>,)>(con)
+        .query_async::<(Vec<u8>,)>(con)
         .await
         .context("Failed to set/get from redis")?;
 


### PR DESCRIPTION
Recreation of #10 

Currently, `RedisPool` doesn't work with `redis-rs 0.26.0` due to breaking change in it.
This PR adapts `RedisPool` to `redis-rs 0.26.0`.

This require to update `AxumSession` too like: https://github.com/AkiraMiyakoda/AxumSession/commit/fb4fca2349ea79936ec69b3627c9c1ef708a7cc1 to work.
I'm ready to create a PR on it too. However, it refers to my own repository instead of crates.io temporarily. 

IMO, it's better to update `AxumSession` by yourselves to keep your history clean.