### PR TITLE
fix misspelled function names

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -34,16 +34,16 @@ where
         }
     }
 
-    pub async fn aquire(&self) -> Result<RedisPoolConnection<C>, RedisPoolError> {
+    pub async fn acquire(&self) -> Result<RedisPoolConnection<C>, RedisPoolError> {
         let permit = match &self.sem {
             Some(sem) => Some(sem.clone().acquire_owned().await?),
             None => None,
         };
-        let con = self.aquire_connection().await?;
+        let con = self.acquire_connection().await?;
         Ok(RedisPoolConnection::new(con, permit, self.queue.clone()))
     }
 
-    async fn aquire_connection(&self) -> RedisResult<C> {
+    async fn acquire_connection(&self) -> RedisResult<C> {
         while let Some(mut con) = self.queue.pop() {
             let res = redis::Pipeline::with_capacity(2)
                 .cmd("UNWATCH")
@@ -67,6 +67,16 @@ where
         }
 
         self.factory.create().await
+    }
+
+    #[deprecated(since = "0.5.0", note = "Please use `acquire` instead")]
+    pub async fn aquire(&self) -> Result<RedisPoolConnection<C>, RedisPoolError> {
+        self.acquire().await
+    }
+
+    #[deprecated(since = "0.5.0", note = "Please use `acquire_connection` instead")]
+    async fn aquire_connection(&self) -> RedisResult<C> {
+        self.acquire_connection().await
     }
 
     pub fn factory(&self) -> &F {

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -15,7 +15,7 @@ pub async fn test_simple_get_set_series() -> anyhow::Result<()> {
     let pool = RedisPool::from(cluster.client());
 
     for i in 0..1000 {
-        let mut con = pool.aquire().await?;
+        let mut con = pool.acquire().await?;
         let (value,) = redis::Pipeline::with_capacity(2)
             .set(i, i)
             .ignore()
@@ -53,7 +53,7 @@ pub async fn test_simple_get_set_parrallel() -> anyhow::Result<()> {
 
 async fn get_set_byte_array(i: usize, pool: &ClusterRedisPool) -> anyhow::Result<Vec<u8>> {
     let mut con = pool
-        .aquire()
+        .acquire()
         .await
         .context("Failed to establish connection")?;
 

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -16,7 +16,7 @@ pub async fn test_simple_get_set_series() -> anyhow::Result<()> {
     let pool = RedisPool::from(redis.client());
 
     for i in 0..50 {
-        let mut con = pool.aquire().await?;
+        let mut con = pool.acquire().await?;
         let (value,) = redis::Pipeline::with_capacity(2)
             .set("test", i)
             .ignore()
@@ -57,7 +57,7 @@ async fn get_set_byte_array_from_pool(
     pool: &SingleRedisPool,
 ) -> anyhow::Result<Vec<u8>> {
     let mut con = pool
-        .aquire()
+        .acquire()
         .await
         .context("Failed to establish connection")?;
 
@@ -81,7 +81,7 @@ pub async fn test_bad_connection_eviction() -> anyhow::Result<()> {
     let docker = Cli::docker();
     let redis = TestRedis::new(&docker);
     let pool = RedisPool::new(ClosableConnectionFactory(redis.client()), 1, Some(1));
-    let mut con = pool.aquire().await.context("Failed to open connection")?;
+    let mut con = pool.acquire().await.context("Failed to open connection")?;
 
     get_set_byte_array("foo", &mut con)
         .await
@@ -96,7 +96,7 @@ pub async fn test_bad_connection_eviction() -> anyhow::Result<()> {
 
     drop(con);
 
-    let mut con = pool.aquire().await.context("Failed to open connection")?;
+    let mut con = pool.acquire().await.context("Failed to open connection")?;
 
     get_set_byte_array("foo", &mut con)
         .await


### PR DESCRIPTION
`RedisPool` has two misspelled functions `aquire` and `aquire_connection` which should be `acquire` and `acquire_connection` respectively.
Changing the function names is a breaking change, so I added new functions and mark the old ones deprecated.